### PR TITLE
Fix/garage door

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Die OpenKNX Smart Home Bridge erlaubt KNX Geräte über Apple Home und Amazon Al
 - SW-Updates können über WLAN (OTA) eigespielt werden
 
 # Release Notes
+- 0.4.2 Fix: Vertauschte Auf-/Zu-Richtung bei Tür, Fenster und Garagentor (sowohl beim Senden auf KNX als auch bei der Rückmeldung an HomeKit)
 - 0.4.1 Fix: Fehler bei Schloss während Sperrvorgang bei benutzerdefinierten Bildern im Display (nicht relevant für SmartHomeBridge)
 - 0.4 Benutzerdefinierte Prozentwerte für Dimmer
 - 0.4 Gerätetype Schloss hinzugefügt

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "OFM-SmartHomeBridge",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "dependencies": {
 
   }

--- a/src/DoorWindow/HomeKitDoorWindow.cpp
+++ b/src/DoorWindow/HomeKitDoorWindow.cpp
@@ -101,7 +101,7 @@ void HomeKitDoorWindow::setMovement(DoorWindowMoveState movement)
             if (targetPosition != nullptr)
                 targetPosition->setVal(receivedTargetPosition);
             if (targetDoorState != nullptr)
-                targetDoorState->setVal(receivedTargetPosition == 0 ?  0 : 1); // 0 .. open 1..close
+                targetDoorState->setVal(receivedTargetPosition == 100 ? 0 : 1); // 0 .. open 1..close
             if (currentPosition != nullptr)
                 currentPosition->setVal(receivedTargetPosition);
             if (currentDoorState != nullptr)

--- a/src/DoorWindow/KnxChannelDoorWindow.cpp
+++ b/src/DoorWindow/KnxChannelDoorWindow.cpp
@@ -160,18 +160,18 @@ bool KnxChannelDoorWindow::commandPosition(DoorWindowBridge* interface, uint8_t 
         switch (getDoorWindowHandling())
         {
             case DoorWindowHandling::DoorWindowHandlingSendOpenAndClose:
-                koSet(KO_OPEN_CLOSE, position == 100, true);
+                koSet(KO_OPEN_CLOSE, position == 0, true);
                 sendPosition = false;
                 break;
             case DoorWindowHandling::DoorWindowHandlingSendClose:
-                if (position == 100)
+                if (position == 0)
                 {
                     koSet(KO_OPEN_CLOSE, true, true);
                     sendPosition = false;
                 };
                 break;
             case DoorWindowHandling::DoorWindowHandlingSendOpen:
-                if (position == 0)
+                if (position == 100)
                 {
                     koSet(KO_OPEN_CLOSE, false, true);
                     sendPosition = false;


### PR DESCRIPTION
## Fix inverted open/close logic in DoorWindow channel

Hi @mgeramb, thanks for your great work! While testing the SmartHomeBridge application I ran into an issue with my garage door. I was only able to close the garage door but wasn't able to open it via HomeKit.

Below you can find a generated description of the two fixes I made in my branch.

---

### Issue 1: Inverted `targetDoorState` for GarageDoor after movement stops

In [`HomeKitDoorWindow::setMovement`](src/DoorWindow/HomeKitDoorWindow.cpp#L104), the `targetDoorState` was set to the wrong value once the door stopped moving. In HomeKit, `0` means *open* and `1` means *close*, so position `100` should map to `0`. As a result, the GarageDoor tile showed the opposite state after the movement finished.

### Issue 2: Inverted DPT_OpenClose value in `commandPosition`

In [`KnxChannelDoorWindow::commandPosition`](src/DoorWindow/KnxChannelDoorWindow.cpp#L160-L181), the value sent on `KO_OPEN_CLOSE` was flipped. DPT_OpenClose (DPT 1.009) defines `0 = Open` and `1 = Close`, but the code sent `Close` on an open command and `Open` on a close command. The `SendOpen` and `SendClose` modes were also triggering on the wrong position. After the fix, all three handling modes send the correct value. Verified with shutters and a garage door — both now move in the expected direction from HomeKit.

---

All this was tested with my Hörmann garage door and the appropriate Hörmann KNX gateway.
<img width="563" height="293" alt="Bildschirmfoto 2026-05-14 um 18 30 19" src="https://github.com/user-attachments/assets/52024d79-0b56-436c-b8e2-74819c7fc2a2" />
<img width="1398" height="130" alt="Bildschirmfoto 2026-05-14 um 18 29 47" src="https://github.com/user-attachments/assets/a2d4c4ab-b46d-4590-a2be-0e35a879f991" />


I would appreciate if you can have a look at it! 

Thanks,
Max